### PR TITLE
Rename bootloader to ubuntu

### DIFF
--- a/mamolinux/modules/bootloader.conf
+++ b/mamolinux/modules/bootloader.conf
@@ -30,4 +30,4 @@ grubCfg: "/boot/grub/grub.cfg"
 # setting the option here, take care to use only valid directory
 # names since no sanitizing is done.
 #
-efiBootloaderId: "mamolinux"
+efiBootloaderId: "ubuntu"


### PR DESCRIPTION
- Ubuntu's grub does not yet support bootloader name other than ubuntu.